### PR TITLE
feat: Change sunday rides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.16.0] - 2023-05-22
+
+### Added
+
+- Automatically archive previous rides on first day of each month.
+
+### Changed
+
+- Added Fast Sunday Ride Group
+- Changed Capuccino to Social Sunday Ride group
+
 ## [1.15.4] - 2023-05-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcc",
-  "version": "1.15.4",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/constants/rides/sundayRides.ts
+++ b/src/constants/rides/sundayRides.ts
@@ -19,6 +19,10 @@ const notes =
 
 export const SUNDAY_RIDES: PartialRide[] = [
   {
+    group: "Fast",
+    distance: 120,
+  },
+  {
     group: "Double Espresso",
     distance: 110,
   },
@@ -31,17 +35,17 @@ export const SUNDAY_RIDES: PartialRide[] = [
     group: "Americano",
     distance: 90,
   },
-  {
-    name: "Long Americano",
-    distance: 100,
-  },
+  // {
+  //   name: "Long Americano",
+  //   distance: 100,
+  // },
   {
     group: "Double Shot Latte",
     distance: 82,
   },
   {
-    group: "Cappuccino",
-    distance: 67,
+    group: "Social",
+    distance: 65,
   },
 ].map((ride) => ({
   name,

--- a/src/pages/api/rides.ts
+++ b/src/pages/api/rides.ts
@@ -38,6 +38,9 @@ export const getRides = async (
         {
           date: "asc",
         },
+        {
+          createdAt: "asc",
+        },
       ],
     });
 


### PR DESCRIPTION
## [1.16.0] - 2023-05-22

### Added

- Automatically archive previous rides on first day of each month.

### Changed

- Added Fast Sunday Ride Group
- Changed Capuccino to Social Sunday Ride group