### PR TITLE
Feature/rider limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.19.0] - 2023-06-26
+
+Paceline rides are getting oversubscribed. This release adds rider limits on rides.
+
+### Added
+
+- Added limit (int) column to Ride table
+- Added limit select to ride form
+
 ## [1.18.0] - 2023-06-21
 
 It's the Longest Day, so to celebrate the Rides app is becoming easier for clubs to customise and host their own version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Paceline rides are getting oversubscribed. This release adds rider limits on rid
 
 - Added limit (int) column to Ride table
 - Added limit select to ride form
+- Added alert to ride details page to show when ride is full; Join button is removed, but a signed-up rider can still leave
+- Added limit of 8 riders to Paceline config (for ride generation)
+- Show count/limit when there is a limit applied (card and details views)
 
 ## [1.18.0] - 2023-06-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcc",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,7 @@ model Ride {
   leader      String?
   notes       String?        @db.Text
   speed       Int?
+  limit       Int            @default(-1)
   users       UsersOnRides[] @relation("usersOnRides_ride")
   deleted     Boolean        @default(false)
   cancelled   Boolean        @default(false)
@@ -139,6 +140,7 @@ model ArchivedRide {
   leader      String?
   notes       String?  @db.Text
   speed       Int?
+  limit       Int      @default(-1)
   deleted     Boolean  @default(false)
   cancelled   Boolean  @default(false)
   createdAt   DateTime @default(now())

--- a/shared/utils/rides.ts
+++ b/shared/utils/rides.ts
@@ -154,3 +154,14 @@ export const makeFilterData = (
   data.delete(undefined);
   return Array.from(data).sort();
 };
+
+export const hasSpace = (ride: RideType): boolean => {
+  const rideLimit = ride.limit || -1;
+  const hasLimit = rideLimit > -1;
+
+  if (!hasLimit) {
+    return true;
+  }
+
+  return (ride.users?.length || 0) < rideLimit;
+};

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,7 +16,8 @@ type Props = {
 export const Card: React.FC<Props> = ({ ride, user }: Props) => {
   const [isSwiping, setSwiping] = useState(false);
   const router = useRouter();
-  const { id, name, date, time, group, destination, distance, users } = ride;
+  const { id, name, date, time, group, destination, distance, limit, users } =
+    ride;
   const isNotReady = !isReady(ride);
 
   const details = destination ? `${destination} - ${distance}` : `${distance}`;
@@ -34,6 +35,8 @@ export const Card: React.FC<Props> = ({ ride, user }: Props) => {
 
   const isGoing = user ? users?.map((u) => u.id).includes(user.id) : false;
   const riderCount = users?.length;
+  const hasLimit = limit && limit > -1;
+  const ridersLabel = hasLimit ? `${riderCount}/${limit}` : riderCount;
 
   const cardClass = clsx(
     "grid w-full grid-cols-[auto_1fr_80px] pl-1 pb-1 border-l-4",
@@ -92,7 +95,7 @@ export const Card: React.FC<Props> = ({ ride, user }: Props) => {
             height={16}
             alt="Number of riders"
           />
-          <span className="text-xl font-bold">{riderCount}</span>
+          <span className="text-xl font-bold">{ridersLabel}</span>
         </div>
       </div>
 

--- a/src/components/RideDetails/index.tsx
+++ b/src/components/RideDetails/index.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 export const RideDetails = ({ ride, user, role, embedded }: Props) => {
   const [showNotesForm, setShowNotesForm] = useState<boolean>(false);
-  const { id, name, date, day, cancelled, users } = ride;
+  const { id, name, date, day, cancelled, limit, users } = ride;
 
   const hasRiders = users && users?.length > 0;
   const isGoing =
@@ -37,6 +37,9 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
   const canJoin = isJoinable(date) && isSpace;
   const rideNotes =
     users && user && users?.find((u: User) => u.id === user.id)?.rideNotes;
+  const riderCount = users?.length || 0;
+  const hasLimit = limit && limit > -1;
+  const ridersLabel = hasLimit ? `${riderCount}/${limit}` : riderCount;
 
   const openNotes = () => setShowNotesForm(true);
   const closeNotes = () => setShowNotesForm(false);
@@ -52,7 +55,7 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
       <Heading>
         <div className="flex items-center gap-4">
           Going
-          <Badge text={users?.length} />
+          <Badge text={ridersLabel} />
         </div>
       </Heading>
 

--- a/src/components/RideDetails/index.tsx
+++ b/src/components/RideDetails/index.tsx
@@ -3,7 +3,7 @@ import { Button, BackButton, JoinButton } from "../Button";
 import { MessageIcon } from "../Icon";
 import { Badge } from "../Badge";
 import { User, Ride } from "../../types";
-import { isJoinable } from "../../../shared/utils";
+import { isJoinable, hasSpace } from "../../../shared/utils";
 import { RideInfo } from "./RideInfo";
 import { RidersGoing } from "./RidersGoing";
 import { RideNotes } from "./RideNotes";
@@ -33,7 +33,8 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
   const isGoing =
     users && user ? users?.map((u: User) => u.id).includes(user?.id) : false;
   const isLeader = ["ADMIN", "LEADER"].includes(role || "");
-  const canJoin = isJoinable(date);
+  const isSpace = hasSpace(ride);
+  const canJoin = isJoinable(date) && isSpace;
   const rideNotes =
     users && user && users?.find((u: User) => u.id === user.id)?.rideNotes;
 
@@ -61,13 +62,17 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
         </div>
       ) : (
         <>
+          {!isSpace && (
+            <div className="alert alert-warning">
+              This ride is full. Please contact the leader if you want to join.
+            </div>
+          )}
           <RidersGoing
             user={user}
             users={users}
             hasRiders={hasRiders}
             isLeader={isLeader}
           />
-
           <div className="flex h-4 flex-row justify-between px-2 pt-2 sm:px-0">
             <BackButton url={`/#${id}`} />
 
@@ -78,7 +83,7 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
               </Button>
             )}
 
-            {user && canJoin && !cancelled && (
+            {user && (canJoin || isGoing) && !cancelled && (
               <JoinButton
                 going={isGoing}
                 ariaLabel={`Join ${name} ride`}

--- a/src/components/RideDetails/index.tsx
+++ b/src/components/RideDetails/index.tsx
@@ -66,8 +66,11 @@ export const RideDetails = ({ ride, user, role, embedded }: Props) => {
       ) : (
         <>
           {!isSpace && (
-            <div className="alert alert-warning">
-              This ride is full. Please contact the leader if you want to join.
+            <div className="mx-2 sm:mx-0">
+              <div className="alert alert-warning">
+                This ride is full. Please contact the leader if you want to
+                join.
+              </div>
             </div>
           )}
           <RidersGoing

--- a/src/components/forms/RideForm.tsx
+++ b/src/components/forms/RideForm.tsx
@@ -1,5 +1,6 @@
 import { FormEventHandler } from "react";
 import { UseFormRegister, FieldErrorsImpl } from "react-hook-form";
+import { RIDER_LIMIT_OPTIONS } from "../../constants";
 import { getNow } from "../../../shared/utils";
 import { Preferences } from "../../types";
 import { Button } from "../Button";
@@ -19,6 +20,7 @@ export type FormValues = {
   distance: number;
   leader: string;
   route: string;
+  limit?: number;
 };
 
 type RideFormProps = {
@@ -60,18 +62,39 @@ export const RideForm = ({
       </label>
     </div>
 
-    <div className="flex flex-col gap-4 md:gap-8">
-      <label htmlFor="group" className="flex flex-col gap-1 font-medium">
-        Group name
-        <input
-          id="group"
-          type="text"
-          className="rounded font-normal"
-          defaultValue={defaultValues.group}
-          {...register("group")}
-        />
-      </label>
+    <div className="grid grid-cols-2 gap-4">
+      <div className="flex flex-col gap-4 md:gap-8">
+        <label htmlFor="group" className="flex flex-col gap-1 font-medium">
+          Group name
+          <input
+            id="group"
+            type="text"
+            className="rounded font-normal"
+            defaultValue={defaultValues.group}
+            {...register("group")}
+          />
+        </label>
+      </div>
+      <div className="flex flex-col gap-4 md:gap-8">
+        <label htmlFor="limit" className="flex flex-col gap-1 font-medium">
+          Rider limit
+          <select
+            id="limit"
+            className="rounded font-normal"
+            defaultValue={defaultValues.limit}
+            {...register("limit")}
+          >
+            <option value="-1">No limit</option>
+            {RIDER_LIMIT_OPTIONS.map((val: number) => (
+              <option key={`limit-${val}`} value={val}>
+                {val}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
     </div>
+
     <div className="grid grid-cols-2 gap-4">
       <div className="flex flex-col gap-4 md:gap-8">
         <label htmlFor="date" className="flex flex-col gap-1 font-medium">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,3 +8,8 @@ export * from "./rides/paceline";
 export * from "./rides/saturdaySocialShort";
 export * from "./rides/saturdaySocialLong";
 export * from "./rides/sundayRides";
+
+// [5 .. 50] rider limit bounds
+export const RIDER_LIMIT_OPTIONS: number[] = Array.from(Array(45).keys()).map(
+  (x) => x + 5
+);

--- a/src/constants/rides/paceline.ts
+++ b/src/constants/rides/paceline.ts
@@ -54,4 +54,5 @@ export const PACELINE = {
   day: DAYS.SATURDAY,
   rides: PACELINE_RIDES,
   startTime: PACELINE_START_TIME,
+  limit: 8, // Max of 8 riders per group
 };

--- a/src/pages/api/ride/create.ts
+++ b/src/pages/api/ride/create.ts
@@ -24,6 +24,8 @@ const createRide = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const ride = req.body;
+    // Cast limit to number
+    ride.limit = +ride.limit;
     // A user can only add themselves; a leader can add other riders
     const hasLeaderRole = await isLeader(req, res);
 

--- a/src/pages/api/ride/edit.ts
+++ b/src/pages/api/ride/edit.ts
@@ -32,6 +32,9 @@ const editRide = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const ride = req.body;
+    // Cast limit to number
+    ride.limit = +ride.limit;
+
     // A user can only add themselves; a leader can add other riders
     const hasLeaderRole = await isLeader(req, res);
     // Do not edit historic rides

--- a/src/pages/ride/[id]/edit.tsx
+++ b/src/pages/ride/[id]/edit.tsx
@@ -55,6 +55,7 @@ const EditRide: NextPage<Props> = ({ data, user }: Props) => {
     leader,
     route,
     notes,
+    limit,
   }) => {
     setWaiting(true);
     // Transform data before sending
@@ -71,6 +72,7 @@ const EditRide: NextPage<Props> = ({ data, user }: Props) => {
         leader,
         route,
         notes,
+        limit,
       })
     );
     if (results.id) {

--- a/src/pages/ride/new.tsx
+++ b/src/pages/ride/new.tsx
@@ -66,6 +66,7 @@ const AddRide: NextPage<Props> = ({ user }: Props) => {
     leader,
     route,
     notes,
+    limit,
   }) => {
     setWaiting(true);
     // Transform data before sending
@@ -81,6 +82,7 @@ const AddRide: NextPage<Props> = ({ user }: Props) => {
         route,
         meetPoint,
         notes,
+        limit,
       })
     );
     if (results.id) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,3 +36,7 @@ svg {
   @apply rounded;
   @apply text-base;
 }
+
+.alert {
+  @apply rounded;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,7 @@ export type Ride = {
   speed?: number | null;
   notes?: string | null;
   cancelled?: boolean;
+  limit?: number;
   users?: User[];
 };
 


### PR DESCRIPTION
## [1.19.0] - 2023-06-26

Paceline rides are getting oversubscribed. This release adds rider limits on rides.

### Added

- Added limit (int) column to Ride table
- Added limit select to ride form
- Added alert to ride details page to show when ride is full; Join button is removed, but a signed-up rider can still leave
- Added limit of 8 riders to Paceline config (for ride generation)
- Show count/limit when there is a limit applied (card and details views)